### PR TITLE
fix: update mrtrix3 paths in docker files

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,10 +11,8 @@ RUN apt-get -qq update \
     cmake \
     && rm -rf /var/lib/apt/lists/*
 
-# Install our package before setting PATH to ensure our designer command (not fsl designer) takes precedenc
 WORKDIR /workspaces/DESIGNER-v2
 COPY . .
-RUN pip install -r requirements.txt && pip install -e .
 
 ENV FSLDIR=/usr/local/fsl
 ENV FSLOUTPUTTYPE=NIFTI_GZ

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,12 +11,16 @@ RUN apt-get -qq update \
     cmake \
     && rm -rf /var/lib/apt/lists/*
 
+# Install our package before setting PATH to ensure our designer command (not fsl designer) takes precedenc
+WORKDIR /workspaces/DESIGNER-v2
+COPY . .
+RUN pip install -r requirements.txt && pip install -e .
 
 ENV FSLDIR=/usr/local/fsl
 ENV FSLOUTPUTTYPE=NIFTI_GZ
 ENV PATH="${PATH}:/usr/local/fsl/bin:/usr/local/mrtrix3_build/bin:/usr/local/ants/bin"
 ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/mrtrix3_build/src:/usr/local/mrtrix3_build/core:/usr/local/ants/lib:/app/rpg_cpp/fftw-3.3.10/build/lib"
-ENV PYTHONPATH="${PYTHONPATH}:/usr/local/mrtrix3_build/lib"
+ENV PYTHONPATH="/usr/local/mrtrix3_build/lib"
 
 RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/v1.1.5/zsh-in-docker.sh)" -- \
     -p git -p ssh-agent -p 'history-substring-search' \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=linux/amd64 python:3.12.1-bookworm
 
 COPY --from=twom/fsl:6.0 /usr/local/fsl /usr/local/fsl
-COPY --from=twom/mrtrix3:dev-latest /usr/local/mrtrix3 /usr/local/mrtrix3
+COPY --from=twom/mrtrix3:dev-latest /usr/local/mrtrix3/build /usr/local/mrtrix3_build
 COPY --from=twom/ants:v2.5.4 /usr/local/ants /usr/local/ants
 
 
@@ -14,9 +14,9 @@ RUN apt-get -qq update \
 
 ENV FSLDIR=/usr/local/fsl
 ENV FSLOUTPUTTYPE=NIFTI_GZ
-ENV PATH="/usr/local/fsl/bin:/usr/local/mrtrix3/build/bin:/usr/local/ants/bin:${PATH}"
-ENV LD_LIBRARY_PATH="/usr/local/mrtrix3/build/lib:/usr/local/ants/lib:/app/rpg_cpp/fftw-3.3.10/build/lib"
-ENV PYTHONPATH="/usr/local/mrtrix3/python/lib"
+ENV PATH="${PATH}:/usr/local/fsl/bin:/usr/local/mrtrix3_build/bin:/usr/local/ants/bin"
+ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/mrtrix3_build/src:/usr/local/mrtrix3_build/core:/usr/local/ants/lib:/app/rpg_cpp/fftw-3.3.10/build/lib"
+ENV PYTHONPATH="${PYTHONPATH}:/usr/local/mrtrix3_build/lib"
 
 RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/v1.1.5/zsh-in-docker.sh)" -- \
     -p git -p ssh-agent -p 'history-substring-search' \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,9 +11,6 @@ RUN apt-get -qq update \
     cmake \
     && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /workspaces/DESIGNER-v2
-COPY . .
-
 ENV FSLDIR=/usr/local/fsl
 ENV FSLOUTPUTTYPE=NIFTI_GZ
 ENV PATH="${PATH}:/usr/local/fsl/bin:/usr/local/mrtrix3_build/bin:/usr/local/ants/bin"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,5 +30,8 @@
 				}
 			}
 		}
-	}
+	},
+	// while this leave the code editable for instant feedback, it's important to note that the terminal session reflects these changes when running our 'designer' command
+	// otherwise, 'designer' command will be linked to the 'fsl designer' package
+	"postCreateCommand": "pip install -e ."
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,6 +30,5 @@
 				}
 			}
 		}
-	},
-	"postCreateCommand": "pip3 install --user -r requirements.txt && python setup.py build_ext"
+	}
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.12.4-bookworm
 
 # Multi stage build from existing dependencies
 COPY --from=twom/fsl:6.0 /usr/local/fsl /usr/local/fsl
-COPY --from=twom/mrtrix3:dev-latest /usr/local/mrtrix3 /usr/local/mrtrix3
+COPY --from=twom/mrtrix3:dev-latest /usr/local/mrtrix3/build /usr/local/mrtrix3_build
 COPY --from=twom/ants:v2.5.4 /usr/local/ants /usr/local/ants
 
 
@@ -39,7 +39,7 @@ RUN python -m pip install .
 
 ENV FSLDIR=/usr/local/fsl
 ENV FSLOUTPUTTYPE=NIFTI_GZ
-ENV PATH="/usr/local/fsl/bin:/usr/local/mrtrix3/build/bin:/usr/local/ants/bin:${PATH}"
-ENV LD_LIBRARY_PATH="/usr/local/mrtrix3/build/lib:/usr/local/ants/lib:/app/rpg_cpp/fftw-3.3.10/build/lib"
-ENV PYTHONPATH="/usr/local/mrtrix3/python/lib"
+ENV PATH="${PATH}:/usr/local/fsl/bin:/usr/local/mrtrix3_build/bin:/usr/local/ants/bin"
+ENV LD_LIBRARY_PATH="/usr/local/mrtrix3_build/src:/usr/local/mrtrix3_build/core:/usr/local/ants/lib:/app/rpg_cpp/fftw-3.3.10/build/lib"
+ENV PYTHONPATH="/usr/local/mrtrix3_build/lib"
 RUN echo ". /usr/local/fsl/etc/fslconf/fsl.sh" >> /root/.bashrc


### PR DESCRIPTION
- Update mrtrix3 build directory name to `mrtrix3_build` to avoid confusions
- Update env variables
- apply editable install in dev container's post-create command