### PR TITLE
Update circleci docker pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
             docker push $DOCKERHUB_USERNAME/designer2:<<parameters.tag>>
 
 workflows:
-  build-on-commit-test:
+  build-on-commit:
     jobs:
       - build:
           tag: commit-${CIRCLE_SHA1}


### PR DESCRIPTION
- Updated circleci workflows; 1) build (without pushing to dockerhub) on all commits, 2) build and push when PR's merged to the main (Github rule needed to prevent direct commit to the main)
- Enabled docker layer caching! (build time around 20s with caching)