### PR TITLE
Optimize CircleCI Docker Pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,9 +62,7 @@ workflows:
           tag: commit-${CIRCLE_SHA1}
           filters:
             branches:
-              ignore:
-                - main
-                - test/circle-ci
+              ignore: main
             tags:
               ignore: /.*/
           context:
@@ -76,9 +74,7 @@ workflows:
           tag: main
           filters:
             branches:
-              only:
-              - main
-              - test/circle-ci
+              only: main
             tags:
               ignore: /.*/
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,19 +29,6 @@ jobs:
           name: Test mrtrix command
           command: |
             docker run -it $DOCKERHUB_USERNAME/designer2:<<parameters.tag>> mrinfo -version
-      - run:
-          name: Save docker image
-          command: |
-            if [ "<< parameters.save_image >>" = "true" ]; then
-              docker save $DOCKERHUB_USERNAME/designer2:<<parameters.tag>> > /tmp/image.tar
-            else
-            # to prevent persist_to_workspace from failing when save_image is false
-              touch /tmp/image.tar
-            fi
-      - persist_to_workspace:
-          root: /tmp
-          paths:
-            - image.tar
   deploy:
     parameters:
       tag:
@@ -49,13 +36,10 @@ jobs:
     docker:
       - image: cimg/base:2024.01
     steps:
-      - attach_workspace:
-          at: /tmp
       - setup_remote_docker
       - run:
           name: Load and push docker image
           command: |
-            docker load < /tmp/image.tar
             echo $DOCKERHUB_PASSWORD | docker login -u $DOCKERHUB_USERNAME --password-stdin
             docker push $DOCKERHUB_USERNAME/designer2:<<parameters.tag>>
 
@@ -66,7 +50,9 @@ workflows:
           tag: commit-${CIRCLE_SHA1}
           filters:
             branches:
-              ignore: main
+              ignore:
+                - main
+                - test/circle-ci
             tags:
               ignore: /.*/
           context:
@@ -78,7 +64,9 @@ workflows:
           save_image: true
           filters:
             branches:
-              only: main
+              only:
+              - main
+              - test/circle-ci
             tags:
               ignore: /.*/
           context:
@@ -89,7 +77,9 @@ workflows:
             - build
           filters:
             branches:
-              only: main
+              only:
+                - main
+                - test/circle-ci
             tags:
               ignore: /.*/
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,9 @@
 version: 2.1
-jobs:
-  build:
+commands:
+  build_docker_image:
     parameters:
       tag:
         type: string
-      save_image:
-        type: boolean
-        default: false
-    docker:
-      - image: cimg/base:2024.01
     steps:
       - checkout
       - setup_remote_docker:
@@ -29,7 +24,21 @@ jobs:
           name: Test mrtrix command
           command: |
             docker run -it $DOCKERHUB_USERNAME/designer2:<<parameters.tag>> mrinfo -version
-  deploy:
+
+jobs:
+  build:
+    parameters:
+      tag:
+        type: string
+    docker:
+      - image: cimg/base:2024.01
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - build_docker_image:
+          tag: <<parameters.tag>>
+  build-and-push:
     parameters:
       tag:
         type: string
@@ -37,8 +46,10 @@ jobs:
       - image: cimg/base:2024.01
     steps:
       - setup_remote_docker
+      - build_docker_image:
+          tag: <<parameters.tag>>
       - run:
-          name: Load and push docker image
+          name: push docker image
           command: |
             echo $DOCKERHUB_PASSWORD | docker login -u $DOCKERHUB_USERNAME --password-stdin
             docker push $DOCKERHUB_USERNAME/designer2:<<parameters.tag>>
@@ -47,6 +58,7 @@ workflows:
   build-on-commit:
     jobs:
       - build:
+          name: "Build Commit 🔨"
           tag: commit-${CIRCLE_SHA1}
           filters:
             branches:
@@ -59,9 +71,9 @@ workflows:
             - DockerHub
   build-and-push-when-merged-to-main:
     jobs:
-      - build:
+      - build-and-push:
+          name: "Deploy Main 🚀"
           tag: main
-          save_image: true
           filters:
             branches:
               only:
@@ -71,35 +83,11 @@ workflows:
               ignore: /.*/
           context:
             - DockerHub
-      - deploy:
-          tag: main
-          requires:
-            - build
-          filters:
-            branches:
-              only:
-                - main
-                - test/circle-ci
-            tags:
-              ignore: /.*/
-          context:
-            - DockerHub
   build-and-push-on-tag:
     jobs:
-      - build:
+      - build-and-push:
+          name: "Deploy Tagged Releases 🚀"
           tag: ${CIRCLE_TAG}
-          save_image: true
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              ignore: /.*/
-          context:
-            - DockerHub
-      - deploy:
-          tag: ${CIRCLE_TAG}
-          requires:
-            - build
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,9 @@ workflows:
     jobs:
       - build:
           tag: commit-${CIRCLE_SHA1}
-          filters:  # works on all branches
+          filters:
+            branches:
+              ignore: main
             tags:
               ignore: /.*/
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,11 @@
 version: 2.1
+
 commands:
   build_docker_image:
     parameters:
       tag:
         type: string
     steps:
-      - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
       - run:
           name: Build and tag docker container
           command: |
@@ -45,7 +43,9 @@ jobs:
     docker:
       - image: cimg/base:2024.01
     steps:
-      - setup_remote_docker
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
       - build_docker_image:
           tag: <<parameters.tag>>
       - run:
@@ -58,7 +58,7 @@ workflows:
   build-on-commit:
     jobs:
       - build:
-          name: "Build Commit 🔨"
+          # name: "Build Commit 🔨"
           tag: commit-${CIRCLE_SHA1}
           filters:
             branches:
@@ -72,7 +72,7 @@ workflows:
   build-and-push-when-merged-to-main:
     jobs:
       - build-and-push:
-          name: "Deploy Main 🚀"
+          # name: "Deploy Main 🚀"
           tag: main
           filters:
             branches:
@@ -86,7 +86,7 @@ workflows:
   build-and-push-on-tag:
     jobs:
       - build-and-push:
-          name: "Deploy Tagged Releases 🚀"
+          # name: "Deploy Tagged Releases 🚀"
           tag: ${CIRCLE_TAG}
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ workflows:
   build-on-commit:
     jobs:
       - build:
-          # name: "Build Commit 🔨"
+          name: "Build Commit 🔨"
           tag: commit-${CIRCLE_SHA1}
           filters:
             branches:
@@ -72,7 +72,7 @@ workflows:
   build-and-push-when-merged-to-main:
     jobs:
       - build-and-push:
-          # name: "Deploy Main 🚀"
+          name: "Deploy Main 🚀"
           tag: main
           filters:
             branches:
@@ -86,7 +86,7 @@ workflows:
   build-and-push-on-tag:
     jobs:
       - build-and-push:
-          # name: "Deploy Tagged Releases 🚀"
+          name: "Deploy Tagged Releases 🚀"
           tag: ${CIRCLE_TAG}
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ workflows:
   build-on-commit:
     jobs:
       - build:
-          name: "Build Commit 🔨"
+          name: Build Commit
           tag: commit-${CIRCLE_SHA1}
           filters:
             branches:
@@ -72,7 +72,7 @@ workflows:
   build-and-push-when-merged-to-main:
     jobs:
       - build-and-push:
-          name: "Deploy Main 🚀"
+          name: Deploy Main
           tag: main
           filters:
             branches:
@@ -86,7 +86,7 @@ workflows:
   build-and-push-on-tag:
     jobs:
       - build-and-push:
-          name: "Deploy Tagged Releases 🚀"
+          name: Deploy Tagged Releases
           tag: ${CIRCLE_TAG}
           filters:
             tags:


### PR DESCRIPTION
- More updates made based on the PR #39 
- Solve #37 
- Separated out the reusable command `build_docker_image` instead of using `persist_to_workspace`; Optimizes build and push workflow