### PR TITLE
Update ANTs Dependency and Docker Dependencies Documentation

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,9 @@
 FROM --platform=linux/amd64 python:3.12.1-bookworm AS base
 
 # Copy dependencies from other images
-COPY --from=twom/fsl:6.0 /usr/local/fsl /usr/local/fsl
-COPY --from=twom/mrtrix3:dev-latest /usr/local/mrtrix3/build /usr/local/mrtrix3_build
-COPY --from=twom/ants:v2.5.4 /usr/local/ants /usr/local/ants
+COPY --from=nyudiffusionmri/fsl:2025-06-16 /usr/local/fsl /usr/local/fsl
+COPY --from=nyudiffusionmri/mrtrix3:2025-06-16 /usr/local/mrtrix3/build /usr/local/mrtrix3_build
+COPY --from=nyudiffusionmri/ants:2025-06-16 /usr/local/ants /usr/local/ants
 
 # Install common dependencies
 RUN apt-get -qq update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@
 FROM python:3.12.4-bookworm AS base
 
 # Copy dependencies from other images
-COPY --from=twom/fsl:6.0 /usr/local/fsl /usr/local/fsl
-COPY --from=twom/mrtrix3:dev-latest /usr/local/mrtrix3/build /usr/local/mrtrix3_build
-COPY --from=twom/ants:v2.5.4 /usr/local/ants /usr/local/ants
+COPY --from=nyudiffusionmri/fsl:2025-06-16 /usr/local/fsl /usr/local/fsl
+COPY --from=nyudiffusionmri/mrtrix3:2025-06-16 /usr/local/mrtrix3/build /usr/local/mrtrix3_build
+COPY --from=nyudiffusionmri/ants:2025-06-16 /usr/local/ants /usr/local/ants
 
 # Install common dependencies
 RUN apt-get -qq update \

--- a/docker_deps/Dockerfile_ants
+++ b/docker_deps/Dockerfile_ants
@@ -1,37 +1,28 @@
 FROM python:3.12.4-bookworm AS builder
 
-# Install necessary dependencies
+# Install download/unpack tools
 RUN --mount=type=cache,sharing=private,target=/var/cache/apt \
     apt-get update && \
-    apt-get install -yq --no-install-recommends \
-    g++-11 \
-    cmake \
-    make \
-    ninja-build \
-    git \
+    apt-get install -y --no-install-recommends \
+      curl \
+      unzip \
     && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /usr/local
-
-ARG CC=gcc-11 CXX=g++-11 BUILD_SHARED_LIBS=ON
-
-# Clone and build ANTs
-# https://github.com/ANTsX/ANTs/wiki/Compiling-ANTs-on-Linux-and-Mac-OS
-RUN git clone --branch v2.5.4 --single-branch https://github.com/stnava/ANTs.git
-RUN mkdir build ants \
-    && cd build \
-    && cmake \
-    -GNinja \
-    -DCMAKE_INSTALL_PREFIX=/usr/local/ants \
-    -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS} \
-    -DBUILD_TESTING=OFF \
-    -DRUN_LONG_TESTS=OFF \
-    -DRUN_SHORT_TESTS=OFF \
-    ../ANTs \
-    && cmake --build . --parallel  $(nproc) \
-WORKDIR /usr/local/build/ANTS-build
-RUN cmake --install .
+# Fetch the Ubuntu 22.04 X64 build of ANTs v2.5.4
+WORKDIR /usr/local/ants
+RUN curl -sSL \
+      -o /tmp/ants.zip \
+      https://github.com/ANTsX/ANTs/releases/download/v2.5.4/ants-2.5.4-ubuntu-22.04-X64-gcc.zip && \
+    unzip /tmp/ants.zip && \
+    mv ants-2.5.4/* . && \
+    rm -rf /tmp/ants.zip ants-2.5.4
 
 
-FROM docker.io/debian:bookworm-slim AS base
-COPY --from=builder /usr/local/ants /usr/local/ants
+FROM docker.io/debian:bookworm-slim
+
+RUN mkdir -p /usr/local/ants/bin/
+RUN mkdir -p /usr/local/ants/lib/
+
+# Only copy the N4BiasFieldCorrection binary and library
+COPY --from=builder /usr/local/ants/bin/N4BiasFieldCorrection /usr/local/ants/bin/N4BiasFieldCorrection
+COPY --from=builder /usr/local/ants/lib/libl_N4BiasFieldCorrection.a /usr/local/ants/lib/libl_N4BiasFieldCorrection.a

--- a/docker_deps/Dockerfile_fsl
+++ b/docker_deps/Dockerfile_fsl
@@ -2,7 +2,7 @@ FROM python:3.12.1-bookworm AS fslbuilder
 
 WORKDIR /usr/local
 RUN wget https://fsl.fmrib.ox.ac.uk/fsldownloads/fslconda/releases/fslinstaller.py -O fslinstaller.py
-RUN python fslinstaller.py -d /usr/local/fsl/
+RUN python fslinstaller.py -V 6.0.7 -d /usr/local/fsl/
 
 FROM python:3.12.1-bookworm
 COPY --from=fslbuilder /usr/local/fsl /usr/local/fsl

--- a/docker_deps/Dockerfile_mrtrix
+++ b/docker_deps/Dockerfile_mrtrix
@@ -19,9 +19,7 @@ RUN apt-get -qq update \
     && apt-get clean
 
 # Set build arguments and environment variables
-ARG CC=gcc-11
-ARG CXX=g++-11
-ARG BUILD_SHARED_LIBS=ON
+ARG CC=gcc-11 CXX=g++-11
 
 # Set up build directory
 WORKDIR /usr/local

--- a/docker_deps/README.md
+++ b/docker_deps/README.md
@@ -70,6 +70,7 @@ For example:
 ```sh
 docker build --platform=linux/amd64 -f docker_deps/Dockerfile_mrtrix -t nyudiffusionmri/mrtrix3:2025-06-16 .
 ```
+<br>
 
 2. Update the `COPY` instruction in the main DESIGNER Dockerfile (located in the project root) with the new `$NEW_DATE_TAG`. Then build and test the DESIGNER image locally to ensure compatibility with the updated dependency. You can run tests similar to those in `.circleci/config.yml`:
 
@@ -87,6 +88,7 @@ mrinfo -version
 N4BiasFieldCorrection --help  # Verify ANTs command
 python -c "from lib import rpg; rpg.unring()"  # Verify function availability
 ```
+<br>
 
 3. After successful local testing, push the new dependency image to Docker Hub:
 ```sh
@@ -97,7 +99,9 @@ For example:
 ```sh
 docker push nyudiffusionmri/mrtrix3:2025-06-16
 ```
+<br>
 
 4. Update this README by adding the new image information (tag, commit hash for Docker file, and dependency version) to the appropriate table.
+<br>
 
 5. Create a Pull Request and verify that the new build passes the CI pipeline. If the build fails, you'll need to modify the dependency Docker file and repeat the process from step 1. Once the PR is approved and merged to the main branch, the **nyudiffusionmri/designer2:main** image will be automatically built and pushed to Docker Hub.

--- a/docker_deps/README.md
+++ b/docker_deps/README.md
@@ -1,9 +1,9 @@
 This folder contains Docker files for DESIGNER's main dependencies. All images are hosted on the [nyudiffusionmri Docker Hub](https://hub.docker.com/u/nyudiffusionmri).
 
 The following Docker files are included:
-- `Dockerfile_mrtrix`: For MRtrix3 dependency
-- `Dockerfile_fsl`: For FSL dependency
-- `Dockerfile_ants`: For ANTs dependency
+- `Dockerfile_mrtrix`: MRtrix3 dependency
+- `Dockerfile_fsl`: FSL dependency
+- `Dockerfile_ants`: ANTs dependency
 <br>
 
 All Docker images are tagged with dates in the `YYYY-MM-DD` format.
@@ -27,7 +27,7 @@ Dependency versions are listed in both the Docker files and the tables below.
 
 
 Notes:
-- Due to MRtrix3's API changes (and subsequent deprecation of their dev branch), we've pinned the commit for the `2025-06-16` image. The pinned version can be found in the [MRtrix3 Github](https://github.com/MRtrix3/mrtrix3/tree/205dd53ef).
+- Due to MRtrix3's API changes and subsequent deprecation of their dev branch, we've pinned the commit for the `2025-06-16` image. The pinned version can be found in the [MRtrix3 Github](https://github.com/MRtrix3/mrtrix3/tree/205dd53ef).
 - The `2024-02-09` image is identical to [twom/mrtrix3:dev-latest](https://hub.docker.com/layers/twom/mrtrix3/dev-latest/images/sha256-7630a4cd709cd7b9967f6db5dae112cd3f7be694fb5fc69c6e8ce1c0c3689d0c).
 
 
@@ -59,7 +59,7 @@ Notes:
 
 ## Updating Dependencies
 
-After modifying a dependency's Docker file, follow these steps to update the image:
+When modifying a dependency's Docker file, follow these steps to update the image:
 
 1. Build the image using:
 ```sh
@@ -104,4 +104,4 @@ docker push nyudiffusionmri/mrtrix3:2025-06-16
 4. Update this README by adding the new image information (tag, commit hash for Docker file, and dependency version) to the appropriate table.
 <br>
 
-5. Create a Pull Request and verify that the new build passes the CI pipeline. If the build fails, you'll need to modify the dependency Docker file and repeat the process from step 1. Once the PR is approved and merged to the main branch, the **nyudiffusionmri/designer2:main** image will be automatically built and pushed to Docker Hub.
+5. Create a Pull Request and verify that the new build passes the CI pipeline. If the build fails, modify the dependency Docker file and repeat the process from step 1. Once the PR is approved and merged to the main branch, the **nyudiffusionmri/designer2:main** image will be automatically built and pushed to Docker Hub.

--- a/docker_deps/README.md
+++ b/docker_deps/README.md
@@ -83,7 +83,7 @@ docker run --rm -it --platform=linux/amd64 designer2:test /bin/bash
 
 # Inside the container, run these commands to verify the installation:
 designer -version
-flirt -version
+flirt -version  # verify FSL installation
 mrinfo -version
 N4BiasFieldCorrection --help  # Verify ANTs command
 python -c "from lib import rpg; rpg.unring()"  # Verify function availability
@@ -104,4 +104,4 @@ docker push nyudiffusionmri/mrtrix3:2025-06-16
 4. Update this README by adding the new image information (tag, commit hash for Docker file, and dependency version) to the appropriate table.
 <br>
 
-5. Create a Pull Request and verify that the new build passes the CI pipeline. If the build fails, modify the dependency Docker file and repeat the process from step 1. Once the PR is approved and merged to the main branch, the **nyudiffusionmri/designer2:main** image will be automatically built and pushed to Docker Hub.
+5. Push to GitHub and verify that the new build passes the CI pipeline (`build_on_commit`). If the build fails, modify the dependency Docker file and repeat the process from step 1. Otherwise, create a Pull Request. Once the PR is approved and merged to the main branch, the **nyudiffusionmri/designer2:main** image will be automatically built and pushed to Docker Hub.

--- a/docker_deps/README.md
+++ b/docker_deps/README.md
@@ -1,14 +1,103 @@
-This folder contains Docker files for the main designer dependencies.
+This folder contains Docker files for DESIGNER's main dependencies. All images are hosted on the [nyudiffusionmri Docker Hub](https://hub.docker.com/u/nyudiffusionmri).
 
-- `Dockerfile_mrtrix`: currently builds de dev version of mrtrix. 
-   The Container is pushed to [twom/mrtrix3:dev-latest](https://hub.docker.com/r/twom/mrtrix3/tags)
+The following Docker files are included:
+- `Dockerfile_mrtrix`: For MRtrix3 dependency
+- `Dockerfile_fsl`: For FSL dependency
+- `Dockerfile_ants`: For ANTs dependency
+<br>
 
-- `Dockerfile_fsl`: FSL installations. Currently [twom/fsl:6.0](https://hub.docker.com/r/twom/fsl/tags) 
+All Docker images are tagged with dates in the `YYYY-MM-DD` format.
 
-- `Dockerfile_deps`: Combies FSL and Mrtrix3
+Note: Prior to documenting build and version information, we used images from [Tom's Docker Hub](https://hub.docker.com/u/twom). These have been migrated to the nyudiffusionmri Docker Hub with new date-based tags. The oldest dated image for each dependency matches exactly what we used in [DESIGNER v2.0.13](https://github.com/NYU-DiffusionMRI/DESIGNER-v2/releases/tag/v2.0.13).
+
+You can find the Docker files used to build specific images by combining a commit ID with the dependency file path in the GitHub URL. For example, to find the MRtrix Dockerfile for commit `8ea6505d1b079dfa0baa9845f5a4681411a6aa37`:
+- [https://github.com/NYU-DiffusionMRI/DESIGNER-v2/blob/8ea6505d1b079dfa0baa9845f5a4681411a6aa37/docker_deps/Dockerfile_mrtrix](https://github.com/NYU-DiffusionMRI/DESIGNER-v2/blob/8ea6505d1b079dfa0baa9845f5a4681411a6aa37/docker_deps/Dockerfile_mrtrix)
+
+Dependency versions are listed in both the Docker files and the tables below.
 
 
-## Updating the dependencies
-These dependencies are used to create dependencie container, so designer containers can be easily and quickly build.
+## MRtrix3
+
+[Docker Hub Link](https://hub.docker.com/r/nyudiffusionmri/mrtrix3/tags)
+
+| Docker Tag | Commit Hash for Docker File | Dependency Version |
+| :--------: | :-------------------------: | :----------------: |
+| 2025-06-16 |           9abe8fa           | 205dd53ef (3.4.0)  |
+| 2024-02-09 |             N/A             | 205dd53ef (3.4.0)  |
 
 
+Notes:
+- Due to MRtrix3's API changes (and subsequent deprecation of their dev branch), we've pinned the commit for the `2025-06-16` image. The pinned version can be found in the [MRtrix3 Github](https://github.com/MRtrix3/mrtrix3/tree/205dd53ef).
+- The `2024-02-09` image is identical to [twom/mrtrix3:dev-latest](https://hub.docker.com/layers/twom/mrtrix3/dev-latest/images/sha256-7630a4cd709cd7b9967f6db5dae112cd3f7be694fb5fc69c6e8ce1c0c3689d0c).
+
+
+## FSL
+
+[Docker Hub Link](https://hub.docker.com/r/nyudiffusionmri/fsl/tags)
+
+| Docker Tag | Commit Hash for Docker File | Dependency Version |
+| :--------: | :-------------------------: | :----------------: |
+| 2025-06-16 |           9abe8fa           |       6.0.7        |
+| 2024-02-10 |             N/A             |        N/A         |
+
+Notes:
+- The `2024-02-10` image is identical to [twom/fsl:6.0](https://hub.docker.com/layers/twom/fsl/6.0/images/sha256-4edc064ee849b8d05aaf98049f0d64c4d07dc27e9d61ad6211c1c7559625d58d).
+
+
+## ANTs
+
+[Docker Hub Link](https://hub.docker.com/r/nyudiffusionmri/ants/tags)
+
+| Docker Tag | Commit Hash for Docker File | Dependency Version |
+| :--------: | :-------------------------: | :----------------: |
+| 2025-06-16 |           9abe8fa           |       2.5.4        |
+| 2024-02-10 |             N/A             |       2.5.4        |
+
+Notes:
+- The `2024-02-10` image is identical to [twom/ants:v2.5.4](https://hub.docker.com/layers/twom/ants/v2.5.4/images/sha256-eb186b9a6959c60e360a4c6d38f36adbfac6709e1cc464a63b4fef4635d5fbfc).
+
+
+## Updating Dependencies
+
+After modifying a dependency's Docker file, follow these steps to update the image:
+
+1. Build the image using:
+```sh
+docker build --platform=linux/amd64 -f docker_deps/$DEPENDENCY_DOCKER_FILE_NAME -t nyudiffusionmri/$DEPENDENCY_DOCKER_HUB_REPO:$NEW_DATE_TAG .
+```
+
+For example:
+```sh
+docker build --platform=linux/amd64 -f docker_deps/Dockerfile_mrtrix -t nyudiffusionmri/mrtrix3:2025-06-16 .
+```
+
+2. Update the `COPY` instruction in the main DESIGNER Dockerfile (located in the project root) with the new `$NEW_DATE_TAG`. Then build and test the DESIGNER image locally to ensure compatibility with the updated dependency. You can run tests similar to those in `.circleci/config.yml`:
+
+```sh
+# Build the test image with the updated dependency
+docker build --platform=linux/amd64 -t designer2:test .
+
+# Run the container and verify functionality
+docker run --rm -it --platform=linux/amd64 designer2:test /bin/bash
+
+# Inside the container, run these commands to verify the installation:
+designer -version
+flirt -version
+mrinfo -version
+N4BiasFieldCorrection --help  # Verify ANTs command
+python -c "from lib import rpg; rpg.unring()"  # Verify function availability
+```
+
+3. After successful local testing, push the new dependency image to Docker Hub:
+```sh
+docker push $IMAGE_NAME_WITH_TAG
+```
+
+For example:
+```sh
+docker push nyudiffusionmri/mrtrix3:2025-06-16
+```
+
+4. Update this README by adding the new image information (tag, commit hash for Docker file, and dependency version) to the appropriate table.
+
+5. Create a Pull Request and verify that the new build passes the CI pipeline. If the build fails, you'll need to modify the dependency Docker file and repeat the process from step 1. Once the PR is approved and merged to the main branch, the **nyudiffusionmri/designer2:main** image will be automatically built and pushed to Docker Hub.


### PR DESCRIPTION
- Reduced ANTs (uncompressed) image size from 425 MB to 100 MB, and modified ANTs docker file for reproducibility; All dependencies are now reproducible. (Related task: [dependency documentation](https://github.com/orgs/NYU-DiffusionMRI/projects/1?pane=issue&itemId=114327012))
- Updated documentation for docker dependencies in `docker_deps/README.md`. Constructed a dependency versioning workflow, and provided clear instructions for updating docker dependencies.
- Slight changes in multiple docker files for DESIGNER, dev container, and depdendencies. (Related task: [Migrate dependencies from twom to nyudiffusionmri](https://github.com/orgs/NYU-DiffusionMRI/projects/1/views/1?pane=issue&itemId=114329759))