### PR TITLE
Update ANTs dependency to 2025-05-14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM python:3.12.4-bookworm AS base
 # Copy dependencies from other images
 COPY --from=nyudiffusionmri/fsl:2025-06-16 /usr/local/fsl /usr/local/fsl
 COPY --from=nyudiffusionmri/mrtrix3:2025-06-16 /usr/local/mrtrix3/build /usr/local/mrtrix3_build
-COPY --from=nyudiffusionmri/ants:2025-06-16 /usr/local/ants /usr/local/ants
+COPY --from=nyudiffusionmri/ants:2025-05-14 /usr/local/ants /usr/local/ants
 
 # Install common dependencies
 RUN apt-get -qq update \

--- a/docker_deps/README.md
+++ b/docker_deps/README.md
@@ -51,7 +51,7 @@ Notes:
 | Docker Tag | Commit Hash for Docker File | Dependency Version |
 | :--------: | :-------------------------: | :----------------: |
 | 2025-06-16 |           9abe8fa           |       2.5.4        |
-| 2024-02-10 |             N/A             |       2.5.4        |
+| 2025-05-14 |             N/A             |       2.5.4        |
 
 Notes:
 - The `2024-02-10` image is identical to [twom/ants:v2.5.4](https://hub.docker.com/layers/twom/ants/v2.5.4/images/sha256-eb186b9a6959c60e360a4c6d38f36adbfac6709e1cc464a63b4fef4635d5fbfc).


### PR DESCRIPTION
- revert ANTs dependency image to the one we are using in v2.0.13.
- fix previous tag typo in documentation.

current ANTs docker file has a problem calling `dwibiascorrect ants -bias ...`

```
designer: [ERROR] dwibiascorrect ants -bias biasfield0.mif dwiprebc0.mif dwibc0.mif (designer_func_wrappers.py:1004)
designer: [ERROR] Information from failed command:
designer:
          dwibiascorrect: 
          dwibiascorrect: Note that this script makes use of commands / algorithms that have relevant articles for citation; INCLUDING FROM EXTERNAL SOFTWARE PACKAGES. Please consult the help page (-help option) for more information.
          dwibiascorrect: 
          dwibiascorrect: Generated scratch directory: /data/processing_wobids/dwibiascorrect-tmp-X0PPYS/
          Command:  mrconvert /data/processing_wobids/dwiprebc0.mif /data/processing_wobids/dwibiascorrect-tmp-X0PPYS/in.mif
          dwibiascorrect: Changing to scratch directory (/data/processing_wobids/dwibiascorrect-tmp-X0PPYS/)
          Command:  dwi2mask legacy in.mif mask.mif
          Command:  dwiextract in.mif - -bzero | mrmath - mean mean_bzero.mif -axis 3
          Command:  mrconvert mean_bzero.mif mean_bzero.nii -strides +1,+2,+3
          Command:  mrconvert mask.mif mask.nii -strides +1,+2,+3
          Command:  N4BiasFieldCorrection -d 3 -i mean_bzero.nii -w mask.nii -o [corrected.nii,init_bias.nii] -s 4 -b [100,3] -c [1000,0.0]
          
          dwibiascorrect: [ERROR] N4BiasFieldCorrection -d 3 -i mean_bzero.nii -w mask.nii -o [corrected.nii,init_bias.nii] -s 4 -b [100,3] -c [1000,0.0] (ants.py:72)
          dwibiascorrect: [ERROR] Failed command did not provide any output information
          dwibiascorrect: [ERROR] For debugging, inspect contents of scratch directory: /data/processing_wobids/dwibiascorrect-tmp-X0PPYS/
          dwibiascorrect: Scratch directory retained; location: /data/processing_wobids/dwibiascorrect-tmp-X0PPYS/
designer:
designer: [ERROR] For debugging, inspect contents of scratch directory: /data/processing_wobids
```