### PR TITLE
Fix ANTs dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ commands:
           command: |
             docker run -it $DOCKERHUB_USERNAME/designer2:<<parameters.tag>> mrinfo -version
       - run:
+      # Although this command verifies that the N4BiasFieldCorrection binary is installed, it doesn’t necessarily guarantee that dwibiascorrect ants -bias ... will function correctly.
           name: Test ANTs N4BiasFieldCorrection command
           command: |
             docker run -it $DOCKERHUB_USERNAME/designer2:<<parameters.tag>> N4BiasFieldCorrection --help

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM python:3.12.4-bookworm AS base
 # Copy dependencies from other images
 COPY --from=nyudiffusionmri/fsl:2025-06-16 /usr/local/fsl /usr/local/fsl
 COPY --from=nyudiffusionmri/mrtrix3:2025-06-16 /usr/local/mrtrix3/build /usr/local/mrtrix3_build
-COPY --from=ants:2025-06-20 /usr/local/ants /usr/local/ants
+COPY --from=nyudiffusionmri/ants:2025-06-20 /usr/local/ants /usr/local/ants
 
 # Install common dependencies
 RUN apt-get -qq update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM python:3.12.4-bookworm AS base
 # Copy dependencies from other images
 COPY --from=nyudiffusionmri/fsl:2025-06-16 /usr/local/fsl /usr/local/fsl
 COPY --from=nyudiffusionmri/mrtrix3:2025-06-16 /usr/local/mrtrix3/build /usr/local/mrtrix3_build
-COPY --from=nyudiffusionmri/ants:2025-06-16 /usr/local/ants /usr/local/ants
+COPY --from=ants:2025-06-20 /usr/local/ants /usr/local/ants
 
 # Install common dependencies
 RUN apt-get -qq update \

--- a/docker_deps/Dockerfile_ants
+++ b/docker_deps/Dockerfile_ants
@@ -1,28 +1,52 @@
 FROM python:3.12.4-bookworm AS builder
 
-# Install download/unpack tools
-RUN --mount=type=cache,sharing=private,target=/var/cache/apt \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-      curl \
-      unzip \
-    && rm -rf /var/lib/apt/lists/*
+RUN apt-get -qq update \
+    && apt-get install -yq --no-install-recommends \
+    wget \
+    cmake \
+    gcc-11 \
+    g++-11 \
+    make \
+    ccache \
+    ninja-build \
+    git \
+    libopenblas-dev \
+    liblapack-dev \
+    && rm -rf /var/lib/apt/lists/
 
-# Fetch the Ubuntu 22.04 X64 build of ANTs v2.5.4
+ARG CC=gcc-11 CXX=g++-11
+ENV CCACHE_DIR=/root/.ccache CCACHE_MAXSIZE=1G
+
 WORKDIR /usr/local/ants
-RUN curl -sSL \
-      -o /tmp/ants.zip \
-      https://github.com/ANTsX/ANTs/releases/download/v2.5.4/ants-2.5.4-ubuntu-22.04-X64-gcc.zip && \
-    unzip /tmp/ants.zip && \
-    mv ants-2.5.4/* . && \
-    rm -rf /tmp/ants.zip ants-2.5.4
+RUN wget -q https://github.com/ANTsX/ANTs/archive/refs/tags/v2.5.4.tar.gz \
+    && tar -xzf v2.5.4.tar.gz \
+    && rm v2.5.4.tar.gz \
+    && mv ANTs-2.5.4 ants_code
+
+RUN mkdir build install
+
+# Use a buildkit cache mount for ccache
+RUN --mount=type=cache,id=ccache,target=/root/.ccache \
+    cd build \
+    && cmake \
+        -S ../ants_code \
+        -G Ninja \
+        -DCMAKE_INSTALL_PREFIX=/usr/local/ants/install \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_TESTING=OFF \
+        -DRUN_LONG_TESTS=OFF \
+        -DRUN_SHORT_TESTS=OFF \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+        # solves "illegal instruction error"
+        -DSuperBuild_ANTS_C_OPTIMIZATION_FLAGS="-O3 -mtune=generic -march=x86-64" \
+        -DSuperBuild_ANTS_CXX_OPTIMIZATION_FLAGS="-O3 -mtune=generic -march=x86-64" \
+    && cmake --build . --parallel $(nproc) \
+    && cd ANTS-build \
+    && cmake --install .
 
 
-FROM docker.io/debian:bookworm-slim
+FROM debian:bookworm-slim
 
-RUN mkdir -p /usr/local/ants/bin/
-RUN mkdir -p /usr/local/ants/lib/
-
-# Only copy the N4BiasFieldCorrection binary and library
-COPY --from=builder /usr/local/ants/bin/N4BiasFieldCorrection /usr/local/ants/bin/N4BiasFieldCorrection
-COPY --from=builder /usr/local/ants/lib/libl_N4BiasFieldCorrection.a /usr/local/ants/lib/libl_N4BiasFieldCorrection.a
+COPY --from=builder /usr/local/ants/install /usr/local/ants

--- a/docker_deps/README.md
+++ b/docker_deps/README.md
@@ -50,10 +50,12 @@ Notes:
 
 | Docker Tag | Commit Hash for Docker File | Dependency Version |
 | :--------: | :-------------------------: | :----------------: |
+| 2025-06-20 |           26a0284           |       2.5.4        |
 | 2025-06-16 |           9abe8fa           |       2.5.4        |
 | 2025-05-14 |             N/A             |       2.5.4        |
 
 Notes:
+- The `2025-06-16` image has a bug with `N4BiasFieldCorrection` binary. **Do not use this image.**
 - The `2025-05-14` image is identical to [twom/ants:v2.5.4](https://hub.docker.com/layers/twom/ants/v2.5.4/images/sha256-eb186b9a6959c60e360a4c6d38f36adbfac6709e1cc464a63b4fef4635d5fbfc).
 
 

--- a/docker_deps/README.md
+++ b/docker_deps/README.md
@@ -51,10 +51,10 @@ Notes:
 | Docker Tag | Commit Hash for Docker File | Dependency Version |
 | :--------: | :-------------------------: | :----------------: |
 | 2025-06-16 |           9abe8fa           |       2.5.4        |
-| 2024-02-10 |             N/A             |       2.5.4        |
+| 2025-05-14 |             N/A             |       2.5.4        |
 
 Notes:
-- The `2024-02-10` image is identical to [twom/ants:v2.5.4](https://hub.docker.com/layers/twom/ants/v2.5.4/images/sha256-eb186b9a6959c60e360a4c6d38f36adbfac6709e1cc464a63b4fef4635d5fbfc).
+- The `2025-05-14` image is identical to [twom/ants:v2.5.4](https://hub.docker.com/layers/twom/ants/v2.5.4/images/sha256-eb186b9a6959c60e360a4c6d38f36adbfac6709e1cc464a63b4fef4635d5fbfc).
 
 
 ## Updating Dependencies


### PR DESCRIPTION
- Fix ANTs Dockerfile. `2025-06-16` tag had a bug with `dwibiascorrect ants -bias ...`command. (Related to #43 )
- Tried with official Docker image, but `N4BiasFieldCorrection` command shows `illegal instruction error`. ([ANTs wiki description](https://github.com/ANTsX/ANTs/wiki/Compiling-ANTs-on-Linux-and-Mac-OS#compilation-fails-or-run-time-errors-occur-with-illegal-instruction-errors))
- Also tried ANTs v2.6.2, but not compatible due to ANTs imageio API changes. (Shows errors at `designer2/tmi.py:674`. This can be future work.)