### PR TITLE
fix bug in tmi to save dt after akc corr and fit smooth

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -57,5 +57,7 @@
         "variant": "cpp",
         "vector": "cpp",
         "algorithm": "cpp"
-    }
+    },
+    "python-envs.defaultEnvManager": "ms-python.python:system",
+    "python-envs.pythonProjects": []
 }

--- a/designer2/tmi.py
+++ b/designer2/tmi.py
@@ -340,7 +340,7 @@ def execute(): #pylint: disable=unused-variable
 
             dt_ = {}
             dt_['dt'] = DT
-            save_params(dt_, nii, model='dki_akc', outdir=outdir)
+            save_params(dt_, mif, model='dki_akc', outdir=outdir)
             logger.info("DKT with AKC saved.")
 
             dt_dki = vectorize(DT, mask)
@@ -359,7 +359,7 @@ def execute(): #pylint: disable=unused-variable
                 DT = vectorize(dt_dti, mask)
                 dt_ = {}
                 dt_['dt'] = DT
-                save_params(dt_, nii, model='dti_fitsmooth', outdir=outdir)
+                save_params(dt_, mif, model='dti_fitsmooth', outdir=outdir)
                 logger.info("DT with fit smooth saved.")
 
                 logger.info("DTI fit after smoothing completed.", extra={"dt_dti_shape": dt_dti.shape})
@@ -370,7 +370,7 @@ def execute(): #pylint: disable=unused-variable
                 DT = vectorize(dt_dki, mask)
                 dt_ = {}
                 dt_['dt'] = DT
-                save_params(dt_, nii, model='dki_fitsmooth', outdir=outdir)
+                save_params(dt_, mif, model='dki_fitsmooth', outdir=outdir)
                 logger.info("DKT with fit smooth saved.")
 
                 logger.info("DKI fit after smoothing completed.", extra={"dt_dki_shape": dt_dki.shape})


### PR DESCRIPTION
When I added lines to output dt after akc corr and fit smooth, it was on the designer version before Ben made changes to use mif (instead of nii) as reference when saving output images in tmi. So, the changes I made when calling save_params() was not consistent with his.