### PR TITLE
Solve bug - remove abs value end of mpcomplex

### DIFF
--- a/designer2/tmi.py
+++ b/designer2/tmi.py
@@ -191,6 +191,7 @@ def execute(): #pylint: disable=unused-variable
 
     mif = load_mrtrix('dwi.mif')
     dwi = mif.data
+    dwi=abs(dwi)
     # grad_mif = mif.grad
     # bval = grad_mif[:,3]
     # bvec = grad_mif[:,:3].T

--- a/lib/mpcomplex.py
+++ b/lib/mpcomplex.py
@@ -448,7 +448,7 @@ def main():
    
     (Signal, Sigma, Npars) = denoise(img_mag, kernel=extent, step=[2,2,2],  shrinkage=args.shrinkage, algorithm=args.algorithm, crop=0, phase=img_phi)
     
-    Signal_ants = ants.from_numpy(abs(Signal), origin=img_mag_ants.origin, spacing=img_mag_ants.spacing, direction=img_mag_ants.direction)
+    Signal_ants = ants.from_numpy(Signal, origin=img_mag_ants.origin, spacing=img_mag_ants.spacing, direction=img_mag_ants.direction)
     ants.image_write(Signal_ants, args.output)
 
     if args.noisemap:


### PR DESCRIPTION
This solves #67 

1) removed the absolute value in mpcomplex.py, l451, Signal_ants=ants…from_numpy(Signal,...), just before writing the file

2) in tmi.py, added dwi=abs(dwi) after loading the mif data at the beginning. All subsequent calls of dti/dki/smi will use abs(dwi) whether denoising was complex or magnitude.

NB: the magnitude denoising file was not changed.

This was done in case we want to work on the complex dwi volume after complex denoising but before tmi