### PR TITLE
fix eddy issue—use json readout time

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -58,6 +58,5 @@
         "vector": "cpp",
         "algorithm": "cpp"
     },
-    "python-envs.defaultEnvManager": "ms-python.python:system",
-    "python-envs.pythonProjects": []
+    "python-envs.defaultEnvManager": "ms-python.python:system"
 }

--- a/lib/designer_func_wrappers.py
+++ b/lib/designer_func_wrappers.py
@@ -534,6 +534,7 @@ def run_ants_moco(dwi_metadata):
 def run_eddy(shell_table, dwi_metadata):
     from mrtrix3 import app, run, path, image, fsl, MRtrixError
     from lib.designer_input_utils import splitext_
+    from lib.utils import get_bids_total_readout_time
     import numpy as np
     import json
     import os
@@ -576,6 +577,10 @@ def run_eddy(shell_table, dwi_metadata):
         flag_variable_bshape = False
     else:
         flag_variable_bshape = True
+
+    readout_time_per_volume = np.asarray(dwi_metadata.get('readout_time')) if dwi_metadata.get('readout_time') is not None else None
+
+    # BIDS-backed readout time is only threaded through the active rpe_pair / rpe_all paths.
 
     if flag_variable_TE or flag_variable_bshape:
         if app.ARGS.eddy_groups is None and app.ARGS.eddy_fakeb is None:
@@ -699,7 +704,6 @@ def run_eddy(shell_table, dwi_metadata):
                 gindsi_str = ','.join([str(k) for k in gindsi])
                 ginds.append(gindsi_str)
                 start += len(group_vol_inds[j])            
-           
             run.command('mrconvert -coord 3 "%s" working.mif "%s"' % 
                 (volume_idx,
                 'dwi_pre_eddy_' + str(i) + '.mif'),
@@ -1043,7 +1047,7 @@ def run_eddy(shell_table, dwi_metadata):
             # Call eddy
             pe_dir_arg = pe_dir if app.ARGS.pe_dir is not None else None
             fakeb_grad_arg = fakeb_grad_file if app.ARGS.eddy_fakeb is not None else None
-            run_fsl_eddy(f'working.mif', 'dwiec.mif', brain_mask, eddy_proc_dir, eddy_opts=eddyopts, pe_dir=pe_dir_arg, grad_file=fakeb_grad_arg, topup_prefix=topup_prefix)
+            run_fsl_eddy(f'working.mif', 'dwiec.mif', brain_mask, eddy_proc_dir, eddy_opts=eddyopts, pe_dir=pe_dir_arg, grad_file=fakeb_grad_arg, topup_prefix=topup_prefix, readout_time=dwi_metadata.get('readout_time'))
             
         elif app.ARGS.rpe_none:
             # Create brain mask from mean b0 for eddy
@@ -1053,7 +1057,7 @@ def run_eddy(shell_table, dwi_metadata):
             # Call eddy
             pe_dir_arg = pe_dir if app.ARGS.pe_dir is not None else None
             fakeb_grad_arg = fakeb_grad_file if app.ARGS.eddy_fakeb is not None else None
-            run_fsl_eddy(f'working.mif', 'dwiec.mif', f'{eddy_proc_dir}/b0_brain_mask{fsl_suffix}', eddy_proc_dir, eddy_opts=eddyopts, pe_dir=pe_dir_arg, grad_file=fakeb_grad_arg)
+            run_fsl_eddy(f'working.mif', 'dwiec.mif', f'{eddy_proc_dir}/b0_brain_mask{fsl_suffix}', eddy_proc_dir, eddy_opts=eddyopts, pe_dir=pe_dir_arg, grad_file=fakeb_grad_arg, readout_time=dwi_metadata.get('readout_time'))
             
         elif app.ARGS.rpe_all:
             rpe_dir = app.ARGS.rpe_all
@@ -1198,6 +1202,10 @@ def run_eddy(shell_table, dwi_metadata):
             
 
             # Run topup and prepare mask for eddy
+            readout_time_arg = None
+            if os.path.exists(bidslist[0]) and os.path.exists(rpe_bids_path):
+                n_vols_rev = int(image.Header('dwirpe.mif').size()[3])
+                readout_time_arg = list(np.asarray(dwi_metadata.get('readout_time')).tolist()) + [get_bids_total_readout_time(rpe_bids_path)] * n_vols_rev
             brain_mask, topup_prefix = run_topup_and_prepare_for_eddy(
                 f'{eddy_proc_dir}/{topupinputfile}',
                 pe_dir,
@@ -1210,7 +1218,7 @@ def run_eddy(shell_table, dwi_metadata):
 
             # Call eddy (PE info now in dwipe_rpe.mif header)
             fakeb_grad_arg = fakeb_grad_file if app.ARGS.eddy_fakeb is not None else None
-            run_fsl_eddy(f'dwipe_rpe.mif', 'dwiec.mif', brain_mask, eddy_proc_dir, eddy_opts=eddyopts, grad_file=fakeb_grad_arg, topup_prefix=topup_prefix)
+            run_fsl_eddy(f'dwipe_rpe.mif', 'dwiec.mif', brain_mask, eddy_proc_dir, eddy_opts=eddyopts, grad_file=fakeb_grad_arg, topup_prefix=topup_prefix, readout_time=readout_time_arg)
             
             # Volume recombination with distortion-based weighting
             # Eddy outputs 2N volumes (N forward + N reverse PE), which we combine
@@ -1284,7 +1292,7 @@ def run_eddy(shell_table, dwi_metadata):
             # Call eddy
             pe_dir_arg = pe_dir if app.ARGS.pe_dir is not None else None
             fakeb_grad_arg = fakeb_grad_file if app.ARGS.eddy_fakeb is not None else None
-            run_fsl_eddy(f'working.mif', 'dwiec.mif', brain_mask, eddy_proc_dir, eddy_opts=eddyopts, pe_dir=pe_dir_arg, grad_file=fakeb_grad_arg, topup_prefix=topup_prefix)
+            run_fsl_eddy(f'working.mif', 'dwiec.mif', brain_mask, eddy_proc_dir, eddy_opts=eddyopts, pe_dir=pe_dir_arg, grad_file=fakeb_grad_arg, topup_prefix=topup_prefix, readout_time=dwi_metadata.get('readout_time'))
 
         elif not app.ARGS.rpe_header and not app.ARGS.rpe_all and not app.ARGS.rpe_pair:
             raise MRtrixError("the eddy option must run alongside -rpe_header, -rpe_all, or -rpe_pair option")

--- a/lib/designer_input_utils.py
+++ b/lib/designer_input_utils.py
@@ -287,6 +287,7 @@ def convert_input_data(dwi_metadata):
     import inspect
     import json
     from colorama import Fore
+    from lib.utils import get_bids_total_readout_time
 
     caller = os.path.basename(inspect.stack()[-1].filename)
 
@@ -300,6 +301,7 @@ def convert_input_data(dwi_metadata):
     te_per_series = []
     pf_per_series = []
     ped_per_series = []
+    readout_per_series = []
 
     dwi_n_list = dwi_metadata['dwi_list']
     isdicom = dwi_metadata['isdicom']
@@ -398,6 +400,7 @@ def convert_input_data(dwi_metadata):
             run.command(cmd)
         dwi_header = image.Header("%s/dwi.mif" % (app.SCRATCH_DIR))
         dwi_ind_size.append([ int(s) for s in dwi_header.size() ])
+        readout_per_series.append(get_bids_total_readout_time(dwi_header.keyval()))
         
         if caller == 'designer':
             if app.ARGS.pf:
@@ -485,6 +488,7 @@ def convert_input_data(dwi_metadata):
             dwi_header = image.Header("%s/dwi%s.mif" % (app.SCRATCH_DIR, str(idx)))
             dwi_ind_size.append([ int(s) for s in dwi_header.size() ])
             miflist.append('"%s/dwi%s.mif"' % (app.SCRATCH_DIR, str(idx)))
+            readout_per_series.append(get_bids_total_readout_time(dwi_header.keyval()))
             
             if caller == 'designer':
                 if app.ARGS.pf:
@@ -602,6 +606,7 @@ def convert_input_data(dwi_metadata):
     dwi_ind_size = [i + [1] if len(i)==3 else i for i in dwi_ind_size]
 
     nvols = [i[3] for i in dwi_ind_size]
+    readoutlist = []
     for idx,i in enumerate(dwi_n_list):
         if len(dwi_n_list) == 1:
             tmpidxlist = range(0,num_volumes)
@@ -610,9 +615,11 @@ def convert_input_data(dwi_metadata):
         idxlist.append(','.join(str(i) for i in tmpidxlist))
         telist.append([te_per_series[idx]] * nvols[idx+1])
         bshapelist.append([bshape_per_series[idx]] * nvols[idx+1])
+        readoutlist.append([readout_per_series[idx]] * nvols[idx+1])
 
     telist = [item for sublist in telist for item in sublist]
     bshapelist = [item for sublist in bshapelist for item in sublist]
+    readoutlist = [item for sublist in readoutlist for item in sublist]
 
     if telist_input is not None:
         telist = np.hstack([np.loadtxt(i) for i in telist_input])
@@ -622,6 +629,7 @@ def convert_input_data(dwi_metadata):
     dwi_metadata['idxlist'] = idxlist
     dwi_metadata['echo_time_per_volume'] = np.array(telist)
     dwi_metadata['bshape_per_volume'] = np.array(bshapelist)
+    dwi_metadata['readout_time'] = np.array(readoutlist)
     dwi_metadata['grad'] = grad
 
     if grad is None:

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -1,13 +1,71 @@
 from pathlib import Path
 from typing import Optional
+from collections.abc import Sequence
 import numpy as np
+
+
+def get_bids_total_readout_time(bids_json: str | Path | dict, default: float = 0.1) -> float:
+    """Return the BIDS total readout time if available.
+
+    Prefers ``TotalReadoutTime`` and falls back to the standard BIDS
+    ``EffectiveEchoSpacing * (ReconMatrixPE - 1)`` derivation when needed.
+    """
+    import json
+
+    if isinstance(bids_json, (str, Path)):
+        with open(bids_json) as f:
+            keyval = json.load(f)
+    else:
+        keyval = bids_json
+
+    if 'TotalReadoutTime' in keyval:
+        return float(keyval['TotalReadoutTime'])
+
+    if 'EffectiveEchoSpacing' in keyval:
+        matrix_pe = keyval.get('ReconMatrixPE', keyval.get('AcquisitionMatrixPE'))
+        if matrix_pe is not None:
+            return float(keyval['EffectiveEchoSpacing']) * (int(matrix_pe) - 1)
+
+    return default
+
+
+def _expand_readout_times(
+    readout_time: float | Sequence[float] | None,
+    n_volumes: int,
+    *,
+    n_forward: Optional[int] = None,
+    n_reverse: Optional[int] = None,
+) -> list[float]:
+    if readout_time is None:
+        return [0.1] * n_volumes
+
+    if isinstance(readout_time, np.ndarray):
+        values = readout_time.tolist()
+    elif isinstance(readout_time, Sequence) and not isinstance(readout_time, (str, bytes, Path)):
+        values = list(readout_time)
+    else:
+        values = [readout_time]
+
+    if len(values) == 1:
+        return [float(values[0])] * n_volumes
+
+    if n_forward is not None and n_reverse is not None and len(values) == 2:
+        return [float(values[0])] * n_forward + [float(values[1])] * n_reverse
+
+    if len(values) == n_volumes:
+        return [float(value) for value in values]
+
+    raise ValueError(
+        'readout_time must be a scalar, a single value, a two-value forward/reverse pair, '
+        'or a per-volume sequence matching the input volume count'
+    )
 
 
 def write_manual_pe_scheme(
     outfile: str | Path,
     pe_dir: str,
     n_volumes: int,
-    readout_time: float = 0.1,
+    readout_time: float | Sequence[float] | None = 0.1,
 ):
     """
     Write PE scheme for single-direction acquisition.
@@ -21,10 +79,11 @@ def write_manual_pe_scheme(
     from mrtrix3 import phaseencoding
 
     pe_vec = list(phaseencoding.direction(pe_dir))    # [dx, dy, dz]
+    readout_times = _expand_readout_times(readout_time, n_volumes)
 
     with open(outfile, "w") as f:
-        for _ in range(n_volumes):
-            f.write(f"{pe_vec[0]} {pe_vec[1]} {pe_vec[2]} {readout_time}\n")
+        for value in readout_times:
+            f.write(f"{pe_vec[0]} {pe_vec[1]} {pe_vec[2]} {value}\n")
 
 
 def write_rpe_all_pe_scheme(
@@ -32,7 +91,7 @@ def write_rpe_all_pe_scheme(
     pe_dir: str,
     n_volumes_forward: int,
     n_volumes_reverse: int,
-    readout_time: float = 0.1,
+    readout_time: float | Sequence[float] | None = 0.1,
 ):
     """
     Write PE scheme for -rpe_all acquisition (forward + reverse PE).
@@ -48,14 +107,20 @@ def write_rpe_all_pe_scheme(
 
     pe_vec_fwd = list(phaseencoding.direction(pe_dir))
     pe_vec_rev = [-x for x in pe_vec_fwd]  # Reverse direction
+    readout_times = _expand_readout_times(
+        readout_time,
+        n_volumes_forward + n_volumes_reverse,
+        n_forward=n_volumes_forward,
+        n_reverse=n_volumes_reverse,
+    )
 
     with open(outfile, "w") as f:
         # Forward PE volumes
-        for _ in range(n_volumes_forward):
-            f.write(f"{pe_vec_fwd[0]} {pe_vec_fwd[1]} {pe_vec_fwd[2]} {readout_time}\n")
+        for value in readout_times[:n_volumes_forward]:
+            f.write(f"{pe_vec_fwd[0]} {pe_vec_fwd[1]} {pe_vec_fwd[2]} {value}\n")
         # Reverse PE volumes
-        for _ in range(n_volumes_reverse):
-            f.write(f"{pe_vec_rev[0]} {pe_vec_rev[1]} {pe_vec_rev[2]} {readout_time}\n")
+        for value in readout_times[n_volumes_forward:]:
+            f.write(f"{pe_vec_rev[0]} {pe_vec_rev[1]} {pe_vec_rev[2]} {value}\n")
 
 
 def compute_jacobian_weight_for_rpe_all(
@@ -114,6 +179,7 @@ def run_fsl_eddy(
     topup_prefix: Optional[str] = None,
     pe_dir: Optional[str] = None,
     grad_file: Optional[str] = None,
+    readout_time: float | Sequence[float] | None = None,
 ):
     from mrtrix3 import run, image
 
@@ -128,7 +194,7 @@ def run_fsl_eddy(
     if pe_dir is not None:
         manual_pe_scheme_path = scratch_dir / 'dwi_manual_pe_scheme.txt'
         n_volumes = int(image.Header(mif_input).size()[3])
-        write_manual_pe_scheme(manual_pe_scheme_path, pe_dir, n_volumes)
+        write_manual_pe_scheme(manual_pe_scheme_path, pe_dir, n_volumes, readout_time=readout_time)
         cmd += f' -import_pe_table {manual_pe_scheme_path}'
 
     if grad_file is not None:


### PR DESCRIPTION
This PR fixes #100 
- Thread BIDS TotalReadoutTime through the pipeline: add `get_bids_total_readout_time(...)` and `_expand_readout_times(...)` in utils.py and store per-volume readout_time in designer_input_utils.py.
- Ensure eddy/topup uses those values instead of the 0.1 default value: pass readout_time into `run_fsl_eddy(...)`, update designer_func_wrappers.py (rpe_pair / rpe_all / rpe_header / rpe_none flows).
- Falls back to 0.1 only when no BIDS JSON file exists.